### PR TITLE
fix: resolve #6 — 🟠 [AI-QA] FTS5 SQL injection via unsanitized LIKE terms

### DIFF
--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -370,9 +370,13 @@ public final class MemoryService: Sendable {
                 unionParts.append("""
                     SELECT memory.*, 0.0 AS search_rank
                     FROM memory
-                    WHERE memory.content LIKE ?
+                    WHERE memory.content LIKE ? ESCAPE '\\'
                     """)
-                arguments.append("%\(term)%")
+                let escapedTerm = term
+                    .replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "%", with: "\\%")
+                    .replacingOccurrences(of: "_", with: "\\_")
+                arguments.append("%\(escapedTerm)%")
             }
 
             let innerSQL = unionParts.joined(separator: " UNION ALL ")


### PR DESCRIPTION
## Summary
Auto-fix for #6

## Changes
- fix: resolve issue #6 — escape LIKE wildcard characters in keyword search

## Issue Reference
Closes #6

---
🤖 *此 PR 由 AI Fix Agent 自动创建*