### PR TITLE
fix: resolve #8 — 🟡 [AI-QA] createMemory missing content_hash generation allows duplicates via hash check

### DIFF
--- a/Sources/MemoryCore/Services/DataExporter.swift
+++ b/Sources/MemoryCore/Services/DataExporter.swift
@@ -142,7 +142,8 @@ public struct DataExporter: Sendable {
                     source: source,
                     createdAt: createdAt,
                     updatedAt: updatedAt,
-                    metadata: metadata
+                    metadata: metadata,
+                    contentHash: MemoryService.generateContentHash(content)
                 )
 
                 try insertMemoryDirectly(memory, tags: tags, service: service)

--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import GRDB
 
@@ -70,6 +71,7 @@ public final class MemoryService: Sendable {
             category: category,
             source: source,
             metadata: metadata,
+            contentHash: Self.generateContentHash(content),
             accessCount: 0,
             lastAccessedAt: nil,
             embedding: embeddingData
@@ -109,6 +111,7 @@ public final class MemoryService: Sendable {
 
             if let content {
                 memory.content = content
+                memory.contentHash = Self.generateContentHash(content)
                 // Regenerate embedding for updated content
                 memory.embedding = embeddingService?.embed(content, isQuery: false)
                     .map { EmbeddingService.encodeEmbedding($0) }
@@ -586,6 +589,16 @@ public final class MemoryService: Sendable {
     }
 
     // MARK: - Private Helpers
+
+    /// Generates a SHA256 content hash from the given content string.
+    ///
+    /// Normalizes the content (trim whitespace + lowercase) before hashing,
+    /// matching the approach used by the v3 migration backfill.
+    static func generateContentHash(_ content: String) -> String {
+        let normalized = content.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let hash = SHA256.hash(data: Data(normalized.utf8))
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
 
     /// Insert tags and create join records. Must be called inside a write transaction.
     private func insertTags(_ tags: [String], for memoryId: String, in dbConn: Database) throws {


### PR DESCRIPTION
## Summary
Auto-fix for #8

## Changes
- fix: resolve issue #8 — generate content_hash in createMemory and importMemory to enable hash-based deduplication

## Issue Reference
Closes #8

---
🤖 *此 PR 由 AI Fix Agent 自动创建*