### PR TITLE
fix: resolve #3 — 🟠 [AI-QA] os_unfair_lock in class stored property is unsafe when class moves in memory

### DIFF
--- a/Sources/MemoryCore/Services/EmbeddingService.swift
+++ b/Sources/MemoryCore/Services/EmbeddingService.swift
@@ -230,11 +230,21 @@ public final class EmbeddingService: @unchecked Sendable {
 
 /// A simple unfair lock wrapper that is safe to use from both sync and async contexts.
 private final class Mutex: @unchecked Sendable {
-    private var _lock = os_unfair_lock()
+    private let _lock: UnsafeMutablePointer<os_unfair_lock>
+
+    init() {
+        _lock = .allocate(capacity: 1)
+        _lock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        _lock.deinitialize(count: 1)
+        _lock.deallocate()
+    }
 
     func withLock<T>(_ body: () -> T) -> T {
-        os_unfair_lock_lock(&_lock)
-        defer { os_unfair_lock_unlock(&_lock) }
+        os_unfair_lock_lock(_lock)
+        defer { os_unfair_lock_unlock(_lock) }
         return body()
     }
 }

--- a/Sources/MemoryMCP/ClientManager.swift
+++ b/Sources/MemoryMCP/ClientManager.swift
@@ -319,21 +319,31 @@ actor UDSClientTransport: Transport {
 
 private final class ClientMutex: @unchecked Sendable {
     private var count = 0
-    private var _lock = os_unfair_lock()
+    private let _lock: UnsafeMutablePointer<os_unfair_lock>
+
+    init() {
+        _lock = .allocate(capacity: 1)
+        _lock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        _lock.deinitialize(count: 1)
+        _lock.deallocate()
+    }
 
     func increment() -> Int {
-        os_unfair_lock_lock(&_lock)
+        os_unfair_lock_lock(_lock)
         count += 1
         let result = count
-        os_unfair_lock_unlock(&_lock)
+        os_unfair_lock_unlock(_lock)
         return result
     }
 
     func decrement() -> Int {
-        os_unfair_lock_lock(&_lock)
+        os_unfair_lock_lock(_lock)
         count -= 1
         let result = count
-        os_unfair_lock_unlock(&_lock)
+        os_unfair_lock_unlock(_lock)
         return result
     }
 }
@@ -342,24 +352,34 @@ private final class ClientMutex: @unchecked Sendable {
 
 private final class ActiveClientsMutex: @unchecked Sendable {
     private var tasks: [UUID: Task<Void, Never>] = [:]
-    private var _lock = os_unfair_lock()
+    private let _lock: UnsafeMutablePointer<os_unfair_lock>
+
+    init() {
+        _lock = .allocate(capacity: 1)
+        _lock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        _lock.deinitialize(count: 1)
+        _lock.deallocate()
+    }
 
     func add(id: UUID, task: Task<Void, Never>) {
-        os_unfair_lock_lock(&_lock)
+        os_unfair_lock_lock(_lock)
         tasks[id] = task
-        os_unfair_lock_unlock(&_lock)
+        os_unfair_lock_unlock(_lock)
     }
 
     func remove(id: UUID) {
-        os_unfair_lock_lock(&_lock)
+        os_unfair_lock_lock(_lock)
         tasks.removeValue(forKey: id)
-        os_unfair_lock_unlock(&_lock)
+        os_unfair_lock_unlock(_lock)
     }
 
     func getAll() -> [Task<Void, Never>] {
-        os_unfair_lock_lock(&_lock)
+        os_unfair_lock_lock(_lock)
         let result = Array(tasks.values)
-        os_unfair_lock_unlock(&_lock)
+        os_unfair_lock_unlock(_lock)
         return result
     }
 }


### PR DESCRIPTION
## Summary
Auto-fix for #3

## Changes
- fix: resolve issue #3 — use heap-allocated os_unfair_lock to prevent memory safety issues

## Issue Reference
Closes #3

---
🤖 *此 PR 由 AI Fix Agent 自动创建*