### PR TITLE
fix: resolve #43 — 🟡 [AI-QA] Proxy busy-spins with usleep instead of proper backpressure

### DIFF
--- a/Sources/MemoryMCP/ProxyBridge.swift
+++ b/Sources/MemoryMCP/ProxyBridge.swift
@@ -124,8 +124,16 @@ enum ProxyBridge {
             let written = write(fd, buffer + totalWritten, count - totalWritten)
             if written <= 0 {
                 if errno == EAGAIN || errno == EWOULDBLOCK {
-                    // Brief spin for writable — in practice UDS buffers rarely fill
-                    usleep(100)
+                    // Use poll() to wait for fd to become writable instead of busy-spinning
+                    var pfd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+                    let pollResult = poll(&pfd, 1, 5000) // 5 second timeout
+                    if pollResult < 0 {
+                        return false // poll error
+                    }
+                    if pollResult == 0 {
+                        // Timeout — fd still not writable
+                        return false
+                    }
                     continue
                 }
                 return false


### PR DESCRIPTION
## Summary
Auto-fix for #43

## Changes
- fix: resolve issue #43 — replace usleep busy-spin with poll() for backpressure

## Issue Reference
Closes #43

---
🤖 *此 PR 由 AI Fix Agent 自动创建*