### PR TITLE
fix: resolve #14 — 🟡 [AI-QA] countForCategory fetches up to 100 records to count them instead of using COUNT(*)

### DIFF
--- a/Sources/MemoryToolApp/ViewModels/MemoryViewModel.swift
+++ b/Sources/MemoryToolApp/ViewModels/MemoryViewModel.swift
@@ -227,7 +227,8 @@ final class MemoryViewModel {
         if category == nil {
             return totalCount
         }
-        return (try? service.listMemories(category: category, limit: 100, offset: 0).count) ?? 0
+        guard let counts = try? service.listCategoriesWithCounts() else { return 0 }
+        return counts.first(where: { $0.category == category })?.count ?? 0
     }
 
     // MARK: - Filters


### PR DESCRIPTION
## Summary
Auto-fix for #14

## Changes
- fix: resolve issue #14 — use COUNT(*) query instead of loading records to count them

## Issue Reference
Closes #14

---
🤖 *此 PR 由 AI Fix Agent 自动创建*