### PR TITLE
fix: resolve #52 — 🟠 [AI-QA] SQL injection via unsanitized FTS query terms

### DIFF
--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -470,7 +470,7 @@ public final class MemoryService: Sendable {
             var arguments: [any DatabaseValueConvertible] = []
 
             if !ftsTerms.isEmpty {
-                let ftsQuery = ftsTerms.map { "\"\($0)\"" }.joined(separator: " OR ")
+                let ftsQuery = ftsTerms.map { "\"\($0.replacingOccurrences(of: "\"", with: "\"\""))\"" }.joined(separator: " OR ")
                 unionParts.append("""
                     SELECT memory.*, memory_fts.rank AS search_rank
                     FROM memory


### PR DESCRIPTION
## Summary
Auto-fix for #52

## Changes
- fix: resolve issue #52 — escape double quotes in FTS search terms to prevent SQL injection

## Issue Reference
Closes #52

---
🤖 *此 PR 由 AI Fix Agent 自动创建*