### PR TITLE
fix: resolve #59 — 🟡 [AI-QA] Legacy init(path:) skips memory limits and migration safeguards

### DIFF
--- a/Sources/MemoryCore/Database/AppDatabase.swift
+++ b/Sources/MemoryCore/Database/AppDatabase.swift
@@ -48,11 +48,10 @@ public final class AppDatabase: Sendable {
     }
 
     /// Legacy path-based init — kept for backward compatibility.
+    @available(*, deprecated, message: "Use AppDatabase.create(path:) instead")
     public init(path: String) throws {
-        var config = Configuration()
-        config.journalMode = .wal
-        self.dbWriter = try DatabasePool(path: path, configuration: config)
-        try migrate()
+        let db = try AppDatabase.create(path: path)
+        self.dbWriter = db.dbWriter
     }
 
     private init(dbWriter: any DatabaseWriter) {


### PR DESCRIPTION
## Summary
Auto-fix for #59

## Changes
- fix: resolve issue #59 — legacy init(path:) now delegates to create(path:) for consistent memory limits

## Issue Reference
Closes #59

---
🤖 *此 PR 由 AI Fix Agent 自动创建*