### PR TITLE
fix: resolve #56 — 🟡 [AI-QA] Socket path length calculation uses wrong formula

### DIFF
--- a/Sources/MemoryMCP/DaemonManager.swift
+++ b/Sources/MemoryMCP/DaemonManager.swift
@@ -154,7 +154,7 @@ enum DaemonManager {
             }
         }
 
-        let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+        let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
         let result = withUnsafePointer(to: &addr) { addrPtr in
             addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
                 Darwin.connect(fd, sockaddrPtr, addrLen)
@@ -210,7 +210,7 @@ enum DaemonManager {
             }
         }
 
-        let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+        let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
         let bindResult = withUnsafePointer(to: &addr) { addrPtr in
             addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
                 bind(listenFd, sockaddrPtr, addrLen)
@@ -252,7 +252,7 @@ enum DaemonManager {
             }
         }
 
-        let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+        let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
         let result = withUnsafePointer(to: &addr) { addrPtr in
             addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
                 Darwin.connect(fd, sockaddrPtr, addrLen)


### PR DESCRIPTION
## Summary
Auto-fix for #56

## Changes
- fix: resolve issue #56 — use correct sockaddr_un size for socket address length

## Issue Reference
Closes #56

---
🤖 *此 PR 由 AI Fix Agent 自动创建*