### PR TITLE
fix: resolve #35 — 🔴 [AI-QA] FTS5 content sync table uses rowid but Memory has text primary key

### DIFF
--- a/Sources/MemoryCore/Database/AppDatabase.swift
+++ b/Sources/MemoryCore/Database/AppDatabase.swift
@@ -242,6 +242,55 @@ public final class AppDatabase: Sendable {
             )
         }
 
+        // v4: Fix FTS5 content sync to use stable text id instead of rowid
+        migrator.registerMigration("v4_fts_id_fix") { db in
+            // Drop old triggers and FTS table
+            try db.execute(sql: "DROP TRIGGER IF EXISTS memory_ai")
+            try db.execute(sql: "DROP TRIGGER IF EXISTS memory_ad")
+            try db.execute(sql: "DROP TRIGGER IF EXISTS memory_au")
+            try db.execute(sql: "DROP TABLE IF EXISTS memory_fts")
+
+            // Recreate FTS5 as a standalone table (no external content) with
+            // an id column so we can join back to the memory table reliably.
+            try db.execute(sql: """
+                CREATE VIRTUAL TABLE memory_fts USING fts5(
+                    id UNINDEXED,
+                    content,
+                    category,
+                    source,
+                    tokenize='trigram'
+                )
+                """)
+
+            // Populate FTS with existing data
+            try db.execute(sql: """
+                INSERT INTO memory_fts(id, content, category, source)
+                SELECT id, content, category, source FROM memory
+                """)
+
+            // Sync triggers
+            try db.execute(sql: """
+                CREATE TRIGGER memory_ai AFTER INSERT ON memory BEGIN
+                    INSERT INTO memory_fts(id, content, category, source)
+                    VALUES (NEW.id, NEW.content, NEW.category, NEW.source);
+                END
+                """)
+
+            try db.execute(sql: """
+                CREATE TRIGGER memory_ad AFTER DELETE ON memory BEGIN
+                    DELETE FROM memory_fts WHERE id = OLD.id;
+                END
+                """)
+
+            try db.execute(sql: """
+                CREATE TRIGGER memory_au AFTER UPDATE ON memory BEGIN
+                    DELETE FROM memory_fts WHERE id = OLD.id;
+                    INSERT INTO memory_fts(id, content, category, source)
+                    VALUES (NEW.id, NEW.content, NEW.category, NEW.source);
+                END
+                """)
+        }
+
         return migrator
     }
 

--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -474,7 +474,7 @@ public final class MemoryService: Sendable {
                 unionParts.append("""
                     SELECT memory.*, memory_fts.rank AS search_rank
                     FROM memory
-                    INNER JOIN memory_fts ON memory_fts.rowid = memory.rowid
+                    INNER JOIN memory_fts ON memory_fts.id = memory.id
                         AND memory_fts MATCH ?
                     """)
                 arguments.append(ftsQuery)


### PR DESCRIPTION
## Summary
Auto-fix for #35

## Changes
- fix: resolve issue #35 — use stable text id instead of rowid for FTS5 sync

## Issue Reference
Closes #35

---
🤖 *此 PR 由 AI Fix Agent 自动创建*