### PR TITLE
fix: resolve #38 — 🟡 [AI-QA] countForCategory loads all memories instead of using COUNT query

### DIFF
--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -808,6 +808,13 @@ public final class MemoryService: Sendable {
         }
     }
 
+    /// Returns the number of memories in a specific category using a COUNT query.
+    public func countMemories(category: String) throws -> Int {
+        try db.reader().read { dbConn in
+            try Memory.filter(Column("category") == category).fetchCount(dbConn)
+        }
+    }
+
     // MARK: - Embedding Management
 
     /// Generate and store embeddings for all memories that don't have one yet.

--- a/Sources/MemoryToolApp/ViewModels/MemoryViewModel.swift
+++ b/Sources/MemoryToolApp/ViewModels/MemoryViewModel.swift
@@ -227,8 +227,7 @@ final class MemoryViewModel {
         if category == nil {
             return totalCount
         }
-        guard let counts = try? service.listCategoriesWithCounts() else { return 0 }
-        return counts.first(where: { $0.category == category })?.count ?? 0
+        return (try? service.countMemories(category: category)) ?? 0
     }
 
     // MARK: - Filters


### PR DESCRIPTION
## Summary
Auto-fix for #38

## Changes
- fix: resolve issue #38 — use COUNT query for countForCategory instead of fetching all memories

## Issue Reference
Closes #38

---
🤖 *此 PR 由 AI Fix Agent 自动创建*