### PR TITLE
fix: resolve #55 — 🟡 [AI-QA] Similarly, embedAsync reads modelBundle without lock after ensureLoaded

### DIFF
--- a/Sources/MemoryCore/Services/EmbeddingService.swift
+++ b/Sources/MemoryCore/Services/EmbeddingService.swift
@@ -101,13 +101,17 @@ public final class EmbeddingService: @unchecked Sendable {
     /// - Returns: L2-normalized 384-dim Float array, or nil if model unavailable.
     public func embedAsync(_ text: String, isQuery: Bool = true) async -> [Float]? {
         await ensureLoaded()
-        guard let modelBundle, isAvailable else { return nil }
+        let bundle: XLMRoberta.ModelBundle? = stateMutex.withLock {
+            guard let modelBundle, isAvailable else { return nil }
+            return modelBundle
+        }
+        guard let bundle else { return nil }
 
         let prefix = isQuery ? "query: " : "passage: "
         let prefixedText = prefix + text
 
         do {
-            let encoded = try modelBundle.encode(prefixedText)
+            let encoded = try bundle.encode(prefixedText)
             let shaped = await encoded.cast(to: Float.self).shapedArray(of: Float.self)
             let vector = Array(shaped.scalars)
             if vector.count == Self.dimension {


### PR DESCRIPTION
## Summary
Auto-fix for #55

## Changes
- fix: resolve issue #55 — read modelBundle and isAvailable under stateMutex in embedAsync

## Issue Reference
Closes #55

---
🤖 *此 PR 由 AI Fix Agent 自动创建*