### PR TITLE
fix: resolve #74 — 🟡 [AI-QA] Proxy client handler never exits sleep loop naturally

### DIFF
--- a/Sources/MemoryMCP/ClientManager.swift
+++ b/Sources/MemoryMCP/ClientManager.swift
@@ -158,12 +158,8 @@ final class ClientManager: @unchecked Sendable {
         do {
             try await clientServer.start(transport: transport)
 
-            // Keep alive until the transport disconnects.
-            // The server.start() handles message routing internally.
-            // We wait until the transport's readLoop detects EOF.
-            while !Task.isCancelled {
-                try await Task.sleep(for: .seconds(60))
-            }
+            // Wait until the transport disconnects (e.g. EOF).
+            await clientServer.waitUntilCompleted()
         } catch {
             logToStderr("Daemon: client handler ended: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
Auto-fix for #74

## Changes
- fix: resolve issue #74 — replace infinite sleep loop with waitUntilCompleted()

## Issue Reference
Closes #74

---
🤖 *此 PR 由 AI Fix Agent 自动创建*