### PR TITLE
fix: resolve #76 — 🟡 [AI-QA] Signal handler cleanup race with concurrent accept loop

### DIFF
--- a/Sources/MemoryMCP/main.swift
+++ b/Sources/MemoryMCP/main.swift
@@ -134,9 +134,8 @@ do {
                     // 3. Wait for in-flight proxy client requests to complete (with timeout)
                     await clientManager.gracefulShutdown(timeout: .seconds(5))
 
-                    // 4. Clean up daemon files and close the listen socket
+                    // 4. Clean up daemon files (listen socket is closed by acceptLoop)
                     DaemonManager.cleanupDaemon()
-                    close(listenFd)
 
                     logToStderr("Graceful shutdown complete, exiting.")
                     exit(0)


### PR DESCRIPTION
## Summary
Auto-fix for #76

## Changes
- fix: resolve issue #76 — remove double-close of listenFd in signal handler

## Issue Reference
Closes #76

---
🤖 *此 PR 由 AI Fix Agent 自动创建*