### PR TITLE
fix: resolve #77 — 🟡 [AI-QA] Sync embed() skips lazy model loading

### DIFF
--- a/Sources/MemoryCore/Services/EmbeddingService.swift
+++ b/Sources/MemoryCore/Services/EmbeddingService.swift
@@ -142,6 +142,16 @@ public final class EmbeddingService: @unchecked Sendable {
     ///   calls to prevent thread starvation deadlock when many callers block GCD
     ///   threads concurrently (see Issue #39).
     public func embed(_ text: String, isQuery: Bool = true) -> [Float]? {
+        // Trigger lazy model loading if needed (mirrors embedAsync's ensureLoaded call).
+        let loadSemaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            Task {
+                await self.ensureLoaded()
+                loadSemaphore.signal()
+            }
+        }
+        loadSemaphore.wait()
+
         let bundle = stateMutex.withLock { () -> ModelBundle? in
             guard let modelBundle, isAvailable else { return nil }
             return modelBundle


### PR DESCRIPTION
## Summary
Auto-fix for #77

## Changes
- fix: resolve issue #77 — sync embed() now triggers lazy model loading

## Issue Reference
Closes #77

---
🤖 *此 PR 由 AI Fix Agent 自动创建*