### PR TITLE
fix: resolve #93 — 🟡 [AI-QA] Signal handler uses exit(0) inside Task which may skip cleanup

### DIFF
--- a/Sources/MemoryMCP/main.swift
+++ b/Sources/MemoryMCP/main.swift
@@ -119,9 +119,15 @@ do {
         let clientManager = ClientManager(handler: handler)
 
         // Register cleanup handler with graceful shutdown
+        var shutdownInProgress = false
         let signalSources = [SIGTERM, SIGINT].map { sig -> DispatchSourceSignal in
             let source = DispatchSource.makeSignalSource(signal: sig, queue: .main)
             source.setEventHandler {
+                guard !shutdownInProgress else {
+                    logToStderr("Received signal \(sig) again, shutdown already in progress. Ignoring.")
+                    return
+                }
+                shutdownInProgress = true
                 logToStderr("Received signal \(sig), initiating graceful shutdown...")
 
                 Task {


### PR DESCRIPTION
## Summary
Auto-fix for #93

## Changes
- fix: resolve issue #93 — guard against duplicate signal-triggered shutdown

## Issue Reference
Closes #93

---
🤖 *此 PR 由 AI Fix Agent 自动创建*