### PR TITLE
fix: resolve #95 — 🟡 [AI-QA] createMemory sync version calls embed() twice for new memories

### DIFF
--- a/Sources/MemoryCore/Services/MemoryService.swift
+++ b/Sources/MemoryCore/Services/MemoryService.swift
@@ -104,16 +104,25 @@ public final class MemoryService: Sendable {
         tags: [String]?,
         metadata: String?
     ) throws -> Memory {
+        // Generate embedding once and reuse for both dedup check and storage
+        let embeddingVec = embeddingService?.embed(content, isQuery: false)
+
         // Semantic deduplication: if a similar memory exists, update it instead
-        let dupResult = try checkDuplicate(content: content)
-        if case .similarExists(let existingId, _) = dupResult {
-            if let updated = try updateMemory(id: existingId, content: content, category: category, source: source, metadata: metadata) {
-                return updated
+        if let queryVec = embeddingVec {
+            let results = try batchedEmbeddingSearch(
+                query: queryVec,
+                topK: 1,
+                threshold: 0.85
+            )
+            if let top = results.first {
+                if let updated = try updateMemory(id: top.id, content: content, category: category, source: source, metadata: metadata) {
+                    return updated
+                }
             }
         }
 
-        // Generate embedding
-        let embeddingData = embeddingService?.embed(content, isQuery: false)
+        // Encode the pre-computed embedding for storage
+        let embeddingData = embeddingVec
             .map { EmbeddingService.encodeEmbedding($0) }
 
         let memory = Memory(


### PR DESCRIPTION
## Summary
Auto-fix for #95

## Changes
- fix: resolve issue #95 — cache embedding from dedup check to avoid redundant embed() call

## Issue Reference
Closes #95

---
🤖 *此 PR 由 AI Fix Agent 自动创建*