### PR TITLE
fix: resolve #98 — 🟡 [AI-QA] Proxy bridge doesn't handle partial JSON-RPC messages across poll boundaries correctly with non-blocking stdout

### DIFF
--- a/Sources/MemoryMCP/ProxyBridge.swift
+++ b/Sources/MemoryMCP/ProxyBridge.swift
@@ -25,8 +25,9 @@ enum ProxyBridge {
         let stdinFd = FileHandle.standardInput.fileDescriptor
         let stdoutFd = FileHandle.standardOutput.fileDescriptor
 
-        // Set both fds to non-blocking so reads don't block after poll() wakeup
+        // Set all fds to non-blocking so reads/writes don't block after poll() wakeup
         setNonBlocking(stdinFd)
+        setNonBlocking(stdoutFd)
         setNonBlocking(daemonFd)
 
         let bufferSize = 65536


### PR DESCRIPTION
## Summary
Auto-fix for #98

## Changes
- fix: resolve issue #98 — set stdoutFd to non-blocking for consistent EAGAIN handling

## Issue Reference
Closes #98

---
🤖 *此 PR 由 AI Fix Agent 自动创建*