### PR TITLE
fix: resolve #117 — 🟡 [AI-QA] decodeEmbedding returns wrong-dimension vectors silently

### DIFF
--- a/Sources/MemoryCore/Services/EmbeddingService.swift
+++ b/Sources/MemoryCore/Services/EmbeddingService.swift
@@ -237,7 +237,8 @@ public final class EmbeddingService: @unchecked Sendable {
 
         let floatCount = data.count / floatSize
         if floatCount != dimension {
-            logToStderr("EmbeddingService: decodeEmbedding warning — decoded \(floatCount) floats, expected \(dimension)")
+            logToStderr("EmbeddingService: decodeEmbedding failed — decoded \(floatCount) floats, expected \(dimension)")
+            return []
         }
 
         return data.withUnsafeBytes { raw in


### PR DESCRIPTION
## Summary
Auto-fix for #117

## Changes
- fix: resolve issue #117 — return empty array for dimension-mismatched embeddings

## Issue Reference
Closes #117

---
🤖 *此 PR 由 AI Fix Agent 自动创建*